### PR TITLE
clean up CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Create fake SSH public key
-          command: mkdir -p ~/.ssh && touch ~/.ssh/id_rsa.pub
-      - run:
           name: Install Ansible dependencies
           command: apk add --no-cache git
       - run:
@@ -51,14 +48,12 @@ jobs:
           command: |
             export USER=$(whoami)
             packer build -var-file=packer/rhel7.json packer/template.json
-          # working_directory: ~/project/terraform/env
 
       - run:
           name: Build ubuntu16 AMI
           command: |
             export USER=$(whoami)
             packer build -var-file=packer/ubuntu16.json packer/template.json
-          # working_directory: ~/project/terraform/env
 
 workflows:
   version: 2
@@ -66,18 +61,12 @@ workflows:
   validate_and_deploy:
     jobs:
       - install_ansible_roles
-      - validate_packer:
+      - validate_packer
+      - deploy_images:
+          filters:
+            branches:
+              only:
+                - master
           requires:
             - install_ansible_roles
-      - deploy_images:
-          requires:
             - validate_packer
-      # - deploy_env:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - circle-deploy
-      #     requires:
-      #       - validate_packer
-      #       - validate_terraform

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GSA Security Benchmarks
+# GSA Security Benchmarks [![CircleCI](https://circleci.com/gh/GSA/security-benchmarks.svg?style=svg)](https://circleci.com/gh/GSA/security-benchmarks)
 
 Welcome to the General Services Administration Security Benchmarks repository. Here you can find items to help implement GSA Security Benchmarks, Infrastructure As Code, and other tools for [our DevSecOps work](https://tech.gsa.gov/guides/dev_sec_ops_guide/).
 


### PR DESCRIPTION
No change in functionality, besides parallelizing the build (outside of `master`), and only actually building the image on `master`. We may want to revisit the latter, perhaps tagging it to indicate the branch or something.