### PR TITLE
various CircleCI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Validate Packer templates
           command: make validate_packer
 
-  deploy_images:
+  deploy_rhel7:
     docker:
       - image: 18fgsa/devsecops-builder:alpine
     steps:
@@ -43,6 +43,18 @@ jobs:
             export USER=$(whoami)
             make rhel7
 
+  deploy_ubuntu16:
+    docker:
+      - image: 18fgsa/devsecops-builder:alpine
+    steps:
+      - attach_workspace:
+          at: .
+
+      - add_ssh_keys
+      - run:
+          name: Disable host key checking
+          command: printf "\nHost *\n\tStrictHostKeyChecking no" >> ~/.ssh/config
+
       - run:
           name: Build ubuntu16 AMI
           command: |
@@ -56,7 +68,15 @@ workflows:
     jobs:
       - install_ansible_roles
       - validate_packer
-      - deploy_images:
+      - deploy_rhel7:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - install_ansible_roles
+            - validate_packer
+      - deploy_ubuntu16:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: apk add --no-cache git
       - run:
           name: Download Ansible dependencies
-          command: ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
+          command: make roles
       - persist_to_workspace:
           root: .
           paths:
@@ -22,14 +22,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Validate base template
-          command: packer validate -syntax-only packer/template.json
-      - run:
-          name: Validate rhel7 template
-          command: packer validate -syntax-only -var-file=packer/rhel7.json packer/template.json
-      - run:
-          name: Validate ubuntu16 template
-          command: packer validate -syntax-only -var-file=packer/ubuntu16.json packer/template.json
+          name: Validate Packer templates
+          command: make validate_packer
 
   deploy_images:
     docker:
@@ -47,13 +41,13 @@ jobs:
           name: Build rhel7 AMI
           command: |
             export USER=$(whoami)
-            packer build -var-file=packer/rhel7.json packer/template.json
+            make rhel7
 
       - run:
           name: Build ubuntu16 AMI
           command: |
             export USER=$(whoami)
-            packer build -var-file=packer/ubuntu16.json packer/template.json
+            make ubuntu16
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
     jobs:
       - install_ansible_roles
       - validate_packer
-      - deploy_rhel7:
+      - deploy_rhel7: &deploy
           filters:
             branches:
               only:
@@ -77,10 +77,4 @@ workflows:
             - install_ansible_roles
             - validate_packer
       - deploy_ubuntu16:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - install_ansible_roles
-            - validate_packer
+          <<: *deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
       - run:
           name: Download Ansible dependencies
           command: make roles
+      - run:
+          name: Validate Ansible playbooks
+          command: make validate_ansible
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,15 @@
 version: 2
 jobs:
-  install_ansible_roles:
+  install_and_validate:
     docker:
-      - image: williamyeh/ansible:alpine3
+      - image: 18fgsa/devsecops-builder:alpine
     steps:
       - checkout
+
       - run:
-          name: Install Ansible dependencies
-          command: apk add --no-cache git
+          name: Validate Packer templates
+          command: make validate_packer
+
       - run:
           name: Download Ansible dependencies
           command: make roles
@@ -15,15 +17,6 @@ jobs:
           root: .
           paths:
             - ./*
-
-  validate_packer:
-    docker:
-      - image: hashicorp/packer:light
-    steps:
-      - checkout
-      - run:
-          name: Validate Packer templates
-          command: make validate_packer
 
   deploy_rhel7:
     docker:
@@ -66,15 +59,13 @@ workflows:
 
   validate_and_deploy:
     jobs:
-      - install_ansible_roles
-      - validate_packer
+      - install_and_validate
       - deploy_rhel7: &deploy
           filters:
             branches:
               only:
                 - master
           requires:
-            - install_ansible_roles
-            - validate_packer
+            - install_and_validate
       - deploy_ubuntu16:
           <<: *deploy

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ default: rhel7 ubuntu16
 roles:
 	ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
 
+validate_ansible: roles
+	cd ansible && ansible-playbook --syntax-check rhel7_base.yml
+	cd ansible && ansible-playbook --syntax-check ubuntu16_base.yml
+
 validate_packer:
 	packer validate -syntax-only packer/template.json
 	packer validate -var-file=packer/rhel7.json packer/template.json

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ roles:
 
 validate_packer:
 	packer validate -syntax-only packer/template.json
-	packer validate -syntax-only -var-file=packer/rhel7.json packer/template.json
-	packer validate -syntax-only -var-file=packer/ubuntu16.json packer/template.json
+	packer validate -var-file=packer/rhel7.json packer/template.json
+	packer validate -var-file=packer/ubuntu16.json packer/template.json
 
 rhel7: roles
 	packer build -var-file=packer/rhel7.json packer/template.json

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ default: rhel7 ubuntu16
 roles:
 	ansible-galaxy install -p ansible/roles -r ansible/requirements.yml
 
+validate_packer:
+	packer validate -syntax-only packer/template.json
+	packer validate -syntax-only -var-file=packer/rhel7.json packer/template.json
+	packer validate -syntax-only -var-file=packer/ubuntu16.json packer/template.json
+
 rhel7: roles
 	packer build -var-file=packer/rhel7.json packer/template.json
 


### PR DESCRIPTION
Leverages https://github.com/GSA/devsecops-example/pull/73.

* Moves the non-trivial and non-CircleCI-specific commands into the Makefile
* Reduce number of jobs, which should make the overall build happen faster
* Use the same Docker image for validation and deployment, to ensure software versions are the same
* Validate Ansible playbooks
* Build the AMIs in parallel
* Better Packer validation