### PR TITLE
add script to generate Service Control Policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.csv
+
 # Packer
 *.pem
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ This will create AMIs with names of `<operating system>-base-<timestamp>`.
 
 ## Service Control Policy
 
-GSA uses a spreadsheet to track the approval status of AWS services. To generate a [Service Control Policy](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html) to only allow those services:
+GSA uses a spreadsheet to track the approval status of AWS services. To generate a [Service Control Policy](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html) to only allow approved services:
 
 1. Export a CSV from [the AWS service approval tracking spreadsheet](https://docs.google.com/spreadsheets/d/1kJrPqu10x80LaGQ_oXFDuoPkBdnaXrXTQVF_uJ14-ok/edit#gid=0).
     * Link above only accessible to GSA.
-    * Expects a column called `Service Identifier` with the lower-case namespace values (`ec2`, etc).
+    * Expects columns:
+        * `Service Identifier`, with the lower-case namespace values (`ec2`, etc.)
+        * `Approval Status`, with the word `Approved`...or not
 1. Generate the policy.
 
         $ SRC=path/to/export.csv python3 scp.py

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the General Services Administration Security Benchmarks repository. H
 
 ## What are GSA Security Benchmarks?
 
-The GSA publishes security guides for various operating systems and applications commonly used at the agency. For more information, please refer to the published guides on [insite.gsa.gov](https://insite.gsa.gov/portal/content/627210) (only accessible with GSA account).  
+The GSA publishes security guides for various operating systems and applications commonly used at the agency. For more information, please refer to the published guides on [insite.gsa.gov](https://insite.gsa.gov/portal/content/627210) (only accessible with GSA account).
 
 ## Available Tools
 
@@ -77,6 +77,29 @@ This repository also contains code to build the base server images with all the 
     ```
 
 This will create AMIs with names of `<operating system>-base-<timestamp>`.
+
+## Service Control Policy
+
+GSA uses a spreadsheet to track the approval status of AWS services. To generate a [Service Control Policy](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html) to only allow those services:
+
+1. Export a CSV from [the AWS service approval tracking spreadsheet](https://docs.google.com/spreadsheets/d/1kJrPqu10x80LaGQ_oXFDuoPkBdnaXrXTQVF_uJ14-ok/edit#gid=0).
+    * Link above only accessible to GSA.
+    * Expects a column called `Service Identifier` with the lower-case namespace values (`ec2`, etc).
+1. Generate the policy.
+
+        $ SRC=path/to/export.csv python3 scp.py
+        {
+            "Version": "2012-10-17",
+            ...
+        }
+
+1. Validate the policy.
+    1. [Create a new IAM policy in the AWS Console.](https://console.aws.amazon.com/iam/home#/policies$new?step=edit)
+    1. Paste in the generated JSON.
+    1. Click `Review policy`.
+    1. Review [the warnings/errors](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_policies.html#troubleshoot_policies-unrecognized-visual).
+    1. Close the tab - you don't need to save the policy here.
+1. [Create the Service Control Policy](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html#create_policy) with the generated JSON.
 
 <!-- reference-style links, to de-duplicate URLs and keep the table above readable -->
 

--- a/scp.py
+++ b/scp.py
@@ -1,0 +1,33 @@
+import csv
+import json
+import os
+
+# boilerplate
+policy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+
+SRC = os.getenv('SRC', 'export.csv')
+namespaces = set()
+with open(SRC, newline='') as csvfile:
+    reader = csv.DictReader(csvfile)
+    for row in reader:
+        namespace = row['Service Identifier']
+        if namespace:
+            # TODO check if approved
+            namespaces.add(namespace)
+
+actions = [ns + ':*' for ns in namespaces]
+actions.sort()
+
+policy['Statement'][0]['Action'] = actions
+print(json.dumps(policy, indent=4))

--- a/scp.py
+++ b/scp.py
@@ -2,32 +2,50 @@ import csv
 import json
 import os
 
-# boilerplate
-policy = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}
+
+def is_approved(row):
+    status = row['Approval Status']
+    return 'approved' in status.lower()
+
+
+def get_namespaces(csv_path):
+    results = set()
+    with open(csv_path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            namespace = row['Service Identifier']
+            if namespace and is_approved(row):
+                results.add(namespace)
+
+    return results
+
+def get_actions(namespaces):
+    actions = [ns + ':*' for ns in namespaces]
+    actions.sort()
+    return actions
+
+
+def generate_policy(actions):
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": actions,
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }
+
+
+def csv_to_policy(csv_path):
+    namespaces = get_namespaces(SRC)
+    actions = get_actions(namespaces)
+    return generate_policy(actions)
+
 
 SRC = os.getenv('SRC', 'export.csv')
-namespaces = set()
-with open(SRC, newline='') as csvfile:
-    reader = csv.DictReader(csvfile)
-    for row in reader:
-        namespace = row['Service Identifier']
-        status = row['Approval Status']
-        if namespace and 'approved' in status.lower():
-            namespaces.add(namespace)
-
-actions = [ns + ':*' for ns in namespaces]
-actions.sort()
-policy['Statement'][0]['Action'] = actions
-
+policy = csv_to_policy(SRC)
 print(json.dumps(policy, indent=4))

--- a/scp.py
+++ b/scp.py
@@ -22,12 +22,12 @@ with open(SRC, newline='') as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
         namespace = row['Service Identifier']
-        if namespace:
-            # TODO check if approved
+        status = row['Approval Status']
+        if namespace and 'approved' in status.lower():
             namespaces.add(namespace)
 
 actions = [ns + ':*' for ns in namespaces]
 actions.sort()
-
 policy['Statement'][0]['Action'] = actions
+
 print(json.dumps(policy, indent=4))


### PR DESCRIPTION
The thinking here is that AWS users at GSA need to check [the AWS service tracking spreadsheet](https://docs.google.com/spreadsheets/d/1kJrPqu10x80LaGQ_oXFDuoPkBdnaXrXTQVF_uJ14-ok/edit#gid=0) to know what services they can/can't use. This leaves room for simple mistakes ("Shoot, I thought that service we're using was approved! Can I still get an ATO?").

This pull request adds instructions and code to convert that spreadsheet into a [Service Control Policy](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html) (or IAM policy - same thing, basically), which will enforce what services can be used at an account level.

Note I'm not checking the generated policy into the repository, since it can get out of date quickly, and I'm not sure if Security considers that "sensitive" (not sure why it would be). On the other hand, making the generated copy available here would save users the trouble of having to generate it themselves. Strong feelings?

## TODOs

* [ ] [Get spreadsheet updated to include the namespaces](https://docs.google.com/spreadsheets/d/1kJrPqu10x80LaGQ_oXFDuoPkBdnaXrXTQVF_uJ14-ok/edit?disco=AAAABnIBTlI)