### PR TITLE
handle encoding errors

### DIFF
--- a/scp/generate.py
+++ b/scp/generate.py
@@ -14,7 +14,7 @@ def is_approved(row):
 
 def get_namespaces(csv_path):
     results = set()
-    with open(csv_path, newline='') as csvfile:
+    with open(csv_path, errors='surrogateescape') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             namespace = row['Service Namespace']


### PR DESCRIPTION
Was getting this error with the latest CSV export received via @ManojChalise:

```
$ python3 scp/generate.py
Traceback (most recent call last):
  File "scp/generate.py", line 62, in <module>
    policy = csv_to_policy(SRC)
  File "scp/generate.py", line 50, in csv_to_policy
    namespaces = get_namespaces(csv_path)
  File "scp/generate.py", line 22, in get_namespaces
    for row in reader:
  File "/usr/local/var/pyenv/versions/3.6.4/lib/python3.6/csv.py", line 111, in __next__
    self.fieldnames
  File "/usr/local/var/pyenv/versions/3.6.4/lib/python3.6/csv.py", line 98, in fieldnames
    self._fieldnames = next(self.reader)
  File "/usr/local/var/pyenv/versions/3.6.4/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0x96 in position 8032: ordinal not in range(128)
```

This change sidesteps the issue, which should be fine for our purposes.